### PR TITLE
Update to hapi v19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 
 node_js:
-  - "8"
-  - "10"
+  - "12"
   - "node"
 
 after_script: "npm run coveralls"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/hapipal/hecks#readme",
   "dependencies": {
-    "@hapi/bounce": "1.x.x",
+    "@hapi/bounce": "2.x.x",
     "toys": "2.x.x"
   },
   "peerDependencies": {
@@ -35,9 +35,9 @@
     "express": ">=3 <5"
   },
   "devDependencies": {
-    "@hapi/code": "5.x.x",
+    "@hapi/code": "8.x.x",
     "@hapi/hapi": "18.x.x",
-    "@hapi/lab": "19.x.x",
+    "@hapi/lab": "22.x.x",
     "body-parser": "1.x.x",
     "coveralls": "3.x.x",
     "express": "4.x.x"

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "toys": "2.x.x"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=17 <19",
+    "@hapi/hapi": ">=17 <20",
     "express": ">=3 <5"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/hapi": "18.x.x",
+    "@hapi/hapi": "19.x.x",
     "@hapi/lab": "22.x.x",
     "body-parser": "1.x.x",
     "coveralls": "3.x.x",


### PR DESCRIPTION
Note that this update will break dependencies with node < 12, because hapi v19 only supports node 12.