### PR TITLE
Ignore globals from node 15 in lab tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L -I \"FinalizationRegistry,WeakRef\"",
+    "test": "lab -a @hapi/code -t 100 -L -I \"FinalizationRegistry,WeakRef,AbortController,AbortSignal,EventTarget,Event,MessageChannel,MessagePort,MessageEvent,AggregateError\"",
     "coveralls": "lab -r lcov | coveralls"
   },
   "repository": {


### PR DESCRIPTION
The Travis CI pipeline is broken on current latest node version due to Lab's leak detection. See: https://travis-ci.com/github/hapipal/hecks/jobs/469876186.